### PR TITLE
Exit if a service lacks any images

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -167,6 +167,10 @@ class DockerCompose:
 
                 locals().get(parameter, unsupported)()
 
+            if len(service_image) == 0:
+                print('ERROR: no image specified for %s service' % service)
+                sys.exit(1)
+
             cmd.extend(service_image)
             cmd.extend(service_command)
 


### PR DESCRIPTION
Exit if a service is defined without an image. Otherwise, an invalid
docker service create command is generated.

Resolves #10.
