### PR TITLE
Handle spaces in environment variables

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -150,7 +150,7 @@ class DockerCompose:
                 def environment():
                     if isinstance(value, dict):
                         for k, v in value.items():
-                            cmd.extend(['--env', '{}={}'.format(k, v), '\\\n'])
+                            cmd.extend(['--env', '{}="{}"'.format(k, v), '\\\n'])
                     else:
                         for env in value:
                             if env.startswith('constraint') or env.startswith('affinity'):

--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -150,7 +150,7 @@ class DockerCompose:
                 def environment():
                     if isinstance(value, dict):
                         for k, v in value.items():
-                            cmd.extend(['--env', '{}="{}"'.format(k, v), '\\\n'])
+                            cmd.extend(['--env', '"{}={}"'.format(k, v), '\\\n'])
                     else:
                         for env in value:
                             if env.startswith('constraint') or env.startswith('affinity'):

--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -157,7 +157,7 @@ class DockerCompose:
                                 constraint = env.split(':', 2)[1]
                                 cmd.extend(['--constraint', "'{}'".format(constraint), '\\\n'])
                             else:
-                                cmd.extend(['--env', env, '\\\n'])
+                                cmd.extend(['--env', '"{}"'.format(env), '\\\n'])
 
                 def replicas():
                     cmd.extend(['--replicas', value, '\\\n'])


### PR DESCRIPTION
Quote the value of the --env argument so that environment variables with spaces in them are handled.

Resolves #13.
