### PR TITLE
Fix is_service_exists for similarly named services (second try)

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -65,7 +65,7 @@ class DockerCompose:
                 return stdout
 
     def is_service_exists(self, service):
-        return self.call('docker service ls -f name={} | tail -n +2'.format(self.project_prefix(service)))
+        return self.call('docker service ls | awk \'{{print $2}}\' | egrep "^{}$"'.format(self.project_prefix(service)))
 
     def is_external_network(self, network):
         if not network in self.networks:


### PR DESCRIPTION
The name filter on docker service ls matches on all or part of a task's
name. This means that is_service_exists will erroneously return True if
the service name is a substring of another existing service.

Use awk to extract just the names from docker service ls, then grep for
a line that specifically matches the service being checked for
existence.

Resolves #14. Replaces PR #15.
