### PR TITLE
Python 3 compatible syntax

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -289,7 +289,7 @@ def main():
     if len(args.file) == 0:
         try:
             args.file = map(lambda f: open(f), os.environ['COMPOSE_FILE'].split(':'))
-        except IOError, e:
+        except IOError as e:
             print(e)
             parser.print_help()
             sys.exit(1)


### PR DESCRIPTION
Just install script with Python 3 and run `docker-compose-swarm-mode --help`, and you'll get:

```
Traceback (most recent call last):
  File "/home/yajo/.local/bin/docker-compose-swarm-mode", line 9, in <module>
    load_entry_point('docker-compose-swarm-mode==1.3.0', 'console_scripts', 'docker-compose-swarm-mode')()
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 547, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2720, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2380, in load
    return self.resolve()
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2386, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/yajo/.local/lib/python3.5/site-packages/docker_compose_swarm_mode.py", line 287
    except IOError, e:
                  ^
SyntaxError: invalid syntax
```

This patch fixes that.

@Tecnativa
