### PR TITLE
Format label dicts into key=value items

### DIFF
--- a/docker_compose_swarm_mode.py
+++ b/docker_compose_swarm_mode.py
@@ -144,6 +144,9 @@ class DockerCompose:
                     pass  # unsupported; waiting for https://github.com/docker/docker/issues/24877
 
                 def labels():
+                    if isinstance(value, dict):
+                        value = ('%s=%s' % i for i in value.iteritems())
+
                     for label in value:
                         cmd.extend(['--label', label, '\\\n'])
 


### PR DESCRIPTION
If the Docker Compose file specifies labels as a dictionary instead of
a list, combine the dictionary items as key=value before looping over
the parameter value and emitting --label arguments. Otherwise, only the
dictionary keys will be emitted for the --label arguments.

Resolves #37.